### PR TITLE
driveMotor must be class member

### DIFF
--- a/src/Dragster.cpp
+++ b/src/Dragster.cpp
@@ -64,7 +64,7 @@ void Dragster::led(int state) {
     digitalWrite(13, state);
 }
 
-void driveMotor(int speed, int swapped, byte dir, byte drv) {
+void Dragster::driveMotor(int speed, int swapped, byte dir, byte drv) {
     if (swapped)
         speed = -speed;
     if (speed > 0) {


### PR DESCRIPTION
Fix error: driveMotor must be class member