### PR TITLE
Replace default voltage settings

### DIFF
--- a/src/Dragster.cpp
+++ b/src/Dragster.cpp
@@ -13,9 +13,9 @@
 
 Dragster::Dragster() {
     // default parameters for 3-4 Ohm motors
-    _upperLimit = 32;
-    _lowerForwardLimit = 15;
-    _lowerBackwardLimit = 21;
+    _upperLimit = 80;
+    _lowerForwardLimit = 25;
+    _lowerBackwardLimit = 25;
 }
 
 Dragster::Dragster(byte upperLimit, byte lowerForwardLimit, byte lowerBackwardLimit) {


### PR DESCRIPTION
Replace default voltage settings. Я смоделировал ситуацию: "человек только что купил драгстер" - поставил новые моторчики, выставил напряжение по рекомендациям из книжки и построил "под нагрузкой" график скорость/(псевдо-напряжение - 0...255) . Поведение новых моторов сильно отличается от моторов замученных экспериментами. Для новых более оптимальны другие настройки, которые я предлагаю использовать как настройки "по умолчанию". Это повышает скорость драгстера не вгоняя его в разрушающие режимы. Если не пытаться "разгонять" моторчики, данными настройками можно будет пользоваться достаточно долгое время.