### PR TITLE
Now, with speed==0 mapped dragster say 'bzzz' - fixed

### DIFF
--- a/src/Dragster.cpp
+++ b/src/Dragster.cpp
@@ -69,7 +69,9 @@ void Dragster::led(int state) {
 void Dragster::driveMotor(int speed, int swapped, byte dir, byte drv) {
     if (swapped)
         speed = -speed;
-    if (speed > 0) {
+    if (speed == 0) {
+        analogWrite(drv, 0);
+    } else if (speed > 0) {
         digitalWrite(dir, HIGH);
         analogWrite(drv, map(speed, 0, 255, _lowerForwardLimit, _upperLimit));
     } else {


### PR DESCRIPTION
Now, with speed==0 mapped dragster say 'bzzz' - fixed. Сейчас, из-за маппирования скорости выбор    скорости равной нулю, ноль маппируется в небольшое число которое меньше скорости при которой драгстер двигается с места. Все вроде правильно, но драгстер стоит на месте и тихонько жужжит. Сделал так что-бы при выборе скорости равной нулю драгстер стоял "молча".